### PR TITLE
Multiple labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabula-rasa",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Node.js SDK for IIIF Presentation API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -18,7 +18,7 @@ export default Model.extend({
       required: 'true',
       default: 'sc:Manifest'
     },
-    label: 'string',
+    label: 'array',
     thumbnail: 'string',
     viewingHint: 'string',
     metadata: 'array'
@@ -51,6 +51,20 @@ export default Model.extend({
         return s
       }
     }
+  },
+
+  parse: function (response) {
+    response.labels = []
+    if (!Array.isArray(response.label)) {
+      var l = { '@value': response.label }
+      response.labels.push(l)
+    } else {
+      response.labels = response.label
+    }
+    response.label = response.labels
+    delete response.labels
+
+    return response
   }
 
 })

--- a/src/test/collection.spec.js
+++ b/src/test/collection.spec.js
@@ -23,11 +23,11 @@ test('a collection must be able to contain a list of manifests', function (asser
   assert.equal(ml.isCollection, true, 'the ManifestList should be an Ampersand Collection')
 
   ml.add([
-    { _id: 'a', label: "Manifest 1"},
-    { _id: 'b', label: "Manifest 2"}
+    { _id: 'a', label: [{ '@value': 'Manifest 1'}] },
+    { _id: 'b', label: [{ '@value': 'Manifest 2'}] }
   ])
 
-  assert.equal(ml.get('a').label, 'Manifest 1', 'the first Manifest in the ManifestList should have a label of Manifest 1')
+  assert.equal(ml.get('a').label[0]['@value'], 'Manifest 1', 'the first Manifest in the ManifestList should have a label of Manifest 1')
 
   c.manifests = ml
   assert.equal(c.manifests.length, 2, 'the collection should have a Manifest List with a length of 2')

--- a/src/test/index.spec.js
+++ b/src/test/index.spec.js
@@ -13,15 +13,15 @@ test('must be able to create a collection with a manifest with a sequence with a
   var ml = new TabulaRasa.ManifestList()
 
   ml.add([
-    { _id: 'foo', '@id': 'bar', label: 'Manifest 1'},
-    { _id: 'fez', '@id': 'baz', label: 'Manifest 2'}
+    { _id: 'foo', '@id': 'bar', label: [{ '@value': 'Manifest 1'}] },
+    { _id: 'fez', '@id': 'baz', label: [{ '@value': 'Manifest 2'}] }
   ])
 
   c.manifests = ml
 
   assert.equal(c.manifests.length, 2, 'the collection should have a Manifest List with a length of 2')
-  assert.equal(c.manifests.get('foo').label, 'Manifest 1', 'should be retrievable by _id')
-  assert.equal(c.manifests.get('baz', '@id').label, 'Manifest 2', 'should be retrievable by @id')
+  assert.equal(c.manifests.get('foo').label[0]['@value'], 'Manifest 1', 'should be retrievable by _id')
+  assert.equal(c.manifests.get('baz', '@id').label[0]['@value'], 'Manifest 2', 'should be retrievable by @id')
 
   assert.end()
 })

--- a/src/test/manifest.spec.js
+++ b/src/test/manifest.spec.js
@@ -19,12 +19,12 @@ test('must be able to get manifest by _id and @id', function (assert) {
   var ml = new ManifestList()
 
   ml.add([
-    { _id: 'foo', '@id': 'bar', label: 'Manifest 1'},
-    { _id: 'fez', '@id': 'baz', label: 'Manifest 2'}
+    { _id: 'foo', '@id': 'bar', label: [{ '@value': 'Manifest 1'}] },
+    { _id: 'fez', '@id': 'baz', label: [{ '@value': 'Manifest 2'}] }
   ])
 
-  assert.equal(ml.get('foo').label, 'Manifest 1', 'should be retrievable by _id')
-  assert.equal(ml.get('baz', '@id').label, 'Manifest 2', 'should be retrievable by @id')
+  assert.equal(ml.get('foo').label[0]['@value'], 'Manifest 1', 'should be retrievable by _id')
+  assert.equal(ml.get('baz', '@id').label[0]['@value'], 'Manifest 2', 'should be retrievable by @id')
 
   assert.end()
 })


### PR DESCRIPTION
Not crazy about this as it requires one to create labels like this as opposed to a simple string:

```
manifest.label = [{ '@value': 'Manifest 1'}]
```

Perhaps some helper function is in order so that it can accept either.
